### PR TITLE
feat: Add Buffer management and workspace persistence

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -728,15 +728,11 @@ require('lazy').setup({
     -- change the command in the config to whatever the name of that colorscheme is.
     --
     -- If you want to see what colorschemes are already installed, you can use `:Telescope colorscheme`.
-    'joshdick/onedark.vim',
-    dependencies = { 'navarasu/onedark.nvim' },
+    'navarasu/onedark.nvim',
     priority = 1000, -- Make sure to load this before all the other start plugins.
     init = function()
       -- Load the colorscheme here.
       vim.cmd.colorscheme 'onedark'
-
-      -- Set's the tabline colorscheme
-      vim.g.lightline = { colorscheme = 'onedark' }
 
       -- You can configure highlights by doing something like:
       vim.cmd.hi 'Comment gui=none'

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -203,14 +203,15 @@ require('lazy').setup({
 
       -- Document existing key chains
       require('which-key').add {
+        { '<leader>b', group = '[B]uffer' },
         { '<leader>c', group = '[C]ode' },
         { '<leader>d', group = '[D]ocument' },
-        { '<leader>r', group = '[R]ename' },
-        { '<leader>s', group = '[S]earch' },
-        { '<leader>w', group = '[W]orkspace' },
-        { '<leader>t', group = '[T]oggle' },
         { '<leader>g', group = '[G]it Fugitive' },
         { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
+        { '<leader>r', group = '[R]ename' },
+        { '<leader>s', group = '[S]earch' },
+        { '<leader>t', group = '[T]oggle' },
+        { '<leader>w', group = '[W]orkspace' },
       }
     end,
   },

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -21,7 +21,7 @@ return {
       vim.g.barbar_auto_setup = false
     end,
     config = function()
-      require('barbar').setup()
+      require('barbar').setup {}
 
       local map = function(keys, func, desc)
         vim.keymap.set('n', keys, func, { desc = '[B]uffer: ' .. desc })
@@ -79,7 +79,15 @@ return {
   { -- Status Bar
     'nvim-lualine/lualine.nvim',
     dependencies = { { 'nvim-tree/nvim-web-devicons', enabled = vim.g.have_nerd_font } },
-    opts = {},
+    opts = {
+      sections = {
+        lualine_c = {
+          function()
+            return require('auto-session.lib').current_session_name(true)
+          end,
+        },
+      },
+    },
   },
   { -- Fzf
     'ibhagwan/fzf-lua',
@@ -149,7 +157,16 @@ return {
   { -- Workspace
     'rmagatti/auto-session',
     config = function()
-      require('auto-session').setup { suppressed_dirs = { '~/', '~/Projects', '~/Downloads', '/' } }
+      vim.opt.sessionoptions = 'blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions,globals'
+      require('auto-session').setup {
+        suppressed_dirs = { '~/', '~/projects', '~/Downloads', '/' },
+
+        pre_save_cmds = {
+          function() -- Barbar can restore buffer order and pins
+            vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
+          end,
+        },
+      }
     end,
   },
 }

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -12,7 +12,53 @@ return {
     end,
   },
   { -- Buffers in the tabline
+    'akinsho/bufferline.nvim',
+    version = '*',
+    dependencies = {
+      { 'nvim-tree/nvim-web-devicons', enabled = vim.g.have_nerd_font },
+    },
+    config = function()
+      require('bufferline').setup {}
+      local map = function(keys, func, desc)
+        vim.keymap.set('n', keys, func, { desc = '[B]uffer: ' .. desc })
+      end
+
+      -- Move to previous/next
+      map('<A-,>', '<Cmd>BufferLineCyclePrev<CR>', 'Previous')
+      map('<A-.>', '<Cmd>BufferLineCycleNext<CR>', 'Next')
+      -- Re-order to previous/next
+      map('<A-<>', '<Cmd>BufferLineMovePrev<CR>', 'Move Previous')
+      map('<A->>', '<Cmd>BufferLineMoveNext<CR>', 'Move Next')
+      -- Goto buffer in position...
+      map('<A-1>', '<Cmd>BufferLineGoToBuffer 1<CR>', 'Goto 1')
+      map('<A-2>', '<Cmd>BufferLineGoToBuffer 2<CR>', 'Goto 2')
+      map('<A-3>', '<Cmd>BufferLineGoToBuffer 3<CR>', 'Goto 3')
+      map('<A-4>', '<Cmd>BufferLineGoToBuffer 4<CR>', 'Goto 4')
+      map('<A-5>', '<Cmd>BufferLineGoToBuffer 5<CR>', 'Goto 5')
+      map('<A-6>', '<Cmd>BufferLineGoToBuffer 6<CR>', 'Goto 6')
+      map('<A-7>', '<Cmd>BufferLineGoToBuffer 7<CR>', 'Goto 7')
+      map('<A-8>', '<Cmd>BufferLineGoToBuffer 8<CR>', 'Goto 8')
+      map('<A-9>', '<Cmd>BufferLineGoToBuffer 9<CR>', 'Goto 9')
+      map('<A-0>', '<Cmd>BufferLineGoToBuffer -1<CR>', 'Goto Last')
+      -- Pin/unpin buffer
+      map('<A-p>', '<Cmd>BufferLineTogglePin<CR>', 'Pin')
+      -- Close buffer
+      map('<A-c>', '<Cmd>BufferLinePickClose<CR>', 'Close')
+      -- Close commands
+      map('<leader>bc', '<Cmd>BufferLineCloseOthers<CR>', '[C]lose Others')
+      --                 :BufferLineCloseLeft
+      --                 :BufferLineCloseRight
+      -- Magic buffer-picking mode
+      map('<C-p>', '<Cmd>BufferLinePick<CR>', 'Pick')
+      -- Sort automatically by...
+      map('<leader>bd', '<Cmd>BufferLineSortByDirectory<CR>', 'Order By [D]irectory')
+      map('<leader>be', '<Cmd>BufferLineSortByExtension<CR>', 'Order By [E]xtension')
+      map('<leader>bt', '<Cmd>BufferLineSortByTabs<CR>', 'Order By [T]abs')
+    end,
+  },
+  { -- Buffers in the tabline
     'romgrk/barbar.nvim',
+    enabled = false,
     dependencies = {
       'lewis6991/gitsigns.nvim', -- OPTIONAL: for git status
       { 'nvim-tree/nvim-web-devicons', enabled = vim.g.have_nerd_font }, -- OPTIONAL: for file icons
@@ -21,7 +67,9 @@ return {
       vim.g.barbar_auto_setup = false
     end,
     config = function()
-      require('barbar').setup {}
+      require('barbar').setup {
+        animation = false,
+      }
 
       local map = function(keys, func, desc)
         vim.keymap.set('n', keys, func, { desc = '[B]uffer: ' .. desc })
@@ -48,6 +96,8 @@ return {
       map('<A-p>', '<Cmd>BufferPin<CR>', 'Pin')
       -- Close buffer
       map('<A-c>', '<Cmd>BufferClose<CR>', 'Close')
+      -- Restore buffer
+      map('<A-s-c>', '<Cmd>BufferRestore<CR>', 'Restore')
       -- Wipeout buffer
       --                 :BufferWipeout
       -- Close commands
@@ -73,17 +123,32 @@ return {
   },
   { -- Session
     'rmagatti/auto-session',
+    dependencies = {
+      {
+        'tiagovla/scope.nvim',
+        config = true,
+      },
+    },
     config = function()
       vim.opt.sessionoptions = 'blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions,globals'
       require('auto-session').setup {
         suppressed_dirs = { '~/', '~/projects', '~/Downloads', '/' },
 
         pre_save_cmds = {
-          function() -- Barbar can restore buffer order and pins
-            vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
-          end,
+          'ScopeSaveState',
+        },
+
+        post_restore_cmds = {
+          'ScopeLoadState',
         },
       }
+    end,
+  },
+  {
+    'tiagovla/scope.nvim',
+    config = function()
+      require('scope').setup {}
+      vim.keymap.set('n', '<leader>bm', '<cmd>ScopeMoveBuf<CR>', { desc = '[B]uffer: Scope [M]ove' })
     end,
   },
   { -- Better TypeScript LSP integration

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -41,7 +41,7 @@ return {
       map('<A-9>', '<Cmd>BufferLineGoToBuffer 9<CR>', 'Goto 9')
       map('<A-0>', '<Cmd>BufferLineGoToBuffer -1<CR>', 'Goto Last')
       -- Pin/unpin buffer
-      map('<A-p>', '<Cmd>BufferLineTogglePin<CR>', 'Pin')
+      -- map('<A-p>', '<Cmd>BufferLineTogglePin<CR>', 'Pin')
       -- Close buffer
       map('<A-c>', '<Cmd>BufferLinePickClose<CR>', 'Close')
       -- Close commands

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -11,7 +11,7 @@ return {
       require('octo').setup { picker = 'fzf-lua' }
     end,
   },
-  {
+  { -- Buffers in the tabline
     'romgrk/barbar.nvim',
     dependencies = {
       'lewis6991/gitsigns.nvim', -- OPTIONAL: for git status
@@ -70,6 +70,21 @@ return {
       -- :BarbarDisable - very bad command, should never be used
     end,
     version = '^1.0.0', -- optional: only update when a new 1.x version is released
+  },
+  { -- Session
+    'rmagatti/auto-session',
+    config = function()
+      vim.opt.sessionoptions = 'blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions,globals'
+      require('auto-session').setup {
+        suppressed_dirs = { '~/', '~/projects', '~/Downloads', '/' },
+
+        pre_save_cmds = {
+          function() -- Barbar can restore buffer order and pins
+            vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
+          end,
+        },
+      }
+    end,
   },
   { -- Better TypeScript LSP integration
     'pmizio/typescript-tools.nvim',
@@ -154,19 +169,4 @@ return {
     build = 'make install',
   },
   'ntpeters/vim-better-whitespace', -- highlights trailing whitespace
-  { -- Workspace
-    'rmagatti/auto-session',
-    config = function()
-      vim.opt.sessionoptions = 'blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions,globals'
-      require('auto-session').setup {
-        suppressed_dirs = { '~/', '~/projects', '~/Downloads', '/' },
-
-        pre_save_cmds = {
-          function() -- Barbar can restore buffer order and pins
-            vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
-          end,
-        },
-      }
-    end,
-  },
 }

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -11,6 +11,18 @@ return {
       require('octo').setup { picker = 'fzf-lua' }
     end,
   },
+  {
+    'romgrk/barbar.nvim',
+    dependencies = {
+      'lewis6991/gitsigns.nvim', -- OPTIONAL: for git status
+      { 'nvim-tree/nvim-web-devicons', enabled = vim.g.have_nerd_font }, -- OPTIONAL: for file icons
+    },
+    init = function()
+      vim.g.barbar_auto_setup = false
+    end,
+    opts = {},
+    version = '^1.0.0', -- optional: only update when a new 1.x version is released
+  },
   { -- Better TypeScript LSP integration
     'pmizio/typescript-tools.nvim',
     dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
@@ -86,11 +98,17 @@ return {
     build = 'make install',
   },
   'ntpeters/vim-better-whitespace', -- highlights trailing whitespace
-  'itchyny/lightline.vim', -- Used to shorten filename in tabs
   { -- Workspace
     'thaerkh/vim-workspace',
     config = function()
       vim.keymap.set('n', '<leader>tw', '<cmd>ToggleWorkspace<CR>', { desc = '[T]oggle [W]orkspace' })
+
+      vim.opt.sessionoptions:append 'globals'
+      vim.api.nvim_create_user_command('Mksession', function(attr)
+        vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
+
+        vim.cmd.mksession { bang = attr.bang, args = attr.fargs }
+      end, { bang = true, complete = 'file', desc = 'Save barbar with :mksession', nargs = '?' })
     end,
   },
 }

--- a/nvim/lua/custom/plugins/init.lua
+++ b/nvim/lua/custom/plugins/init.lua
@@ -20,7 +20,55 @@ return {
     init = function()
       vim.g.barbar_auto_setup = false
     end,
-    opts = {},
+    config = function()
+      require('barbar').setup()
+
+      local map = function(keys, func, desc)
+        vim.keymap.set('n', keys, func, { desc = '[B]uffer: ' .. desc })
+      end
+
+      -- Move to previous/next
+      map('<A-,>', '<Cmd>BufferPrevious<CR>', 'Previous')
+      map('<A-.>', '<Cmd>BufferNext<CR>', 'Next')
+      -- Re-order to previous/next
+      map('<A-<>', '<Cmd>BufferMovePrevious<CR>', 'Move Previous')
+      map('<A->>', '<Cmd>BufferMoveNext<CR>', 'Move Next')
+      -- Goto buffer in position...
+      map('<A-1>', '<Cmd>BufferGoto 1<CR>', 'Goto 1')
+      map('<A-2>', '<Cmd>BufferGoto 2<CR>', 'Goto 2')
+      map('<A-3>', '<Cmd>BufferGoto 3<CR>', 'Goto 3')
+      map('<A-4>', '<Cmd>BufferGoto 4<CR>', 'Goto 4')
+      map('<A-5>', '<Cmd>BufferGoto 5<CR>', 'Goto 5')
+      map('<A-6>', '<Cmd>BufferGoto 6<CR>', 'Goto 6')
+      map('<A-7>', '<Cmd>BufferGoto 7<CR>', 'Goto 7')
+      map('<A-8>', '<Cmd>BufferGoto 8<CR>', 'Goto 8')
+      map('<A-9>', '<Cmd>BufferGoto 9<CR>', 'Goto 9')
+      map('<A-0>', '<Cmd>BufferLast<CR>', 'Goto Last')
+      -- Pin/unpin buffer
+      map('<A-p>', '<Cmd>BufferPin<CR>', 'Pin')
+      -- Close buffer
+      map('<A-c>', '<Cmd>BufferClose<CR>', 'Close')
+      -- Wipeout buffer
+      --                 :BufferWipeout
+      -- Close commands
+      --                 :BufferCloseAllButCurrent
+      --                 :BufferCloseAllButPinned
+      --                 :BufferCloseAllButCurrentOrPinned
+      --                 :BufferCloseBuffersLeft
+      --                 :BufferCloseBuffersRight
+      -- Magic buffer-picking mode
+      map('<C-p>', '<Cmd>BufferPick<CR>', 'Pick')
+      -- Sort automatically by...
+      map('<leader>bb', '<Cmd>BufferOrderByBufferNumber<CR>', 'Order By [B]uffer Number')
+      map('<leader>bn', '<Cmd>BufferOrderByName<CR>', 'Order By [N]ame')
+      map('<leader>bd', '<Cmd>BufferOrderByDirectory<CR>', 'Order By [D]irectory')
+      map('<leader>bl', '<Cmd>BufferOrderByLanguage<CR>', 'Order By [L]anguage')
+      map('<leader>bw', '<Cmd>BufferOrderByWindowNumber<CR>', 'Order By [W]indow Number')
+
+      -- Other:
+      -- :BarbarEnable - enables barbar (enabled by default)
+      -- :BarbarDisable - very bad command, should never be used
+    end,
     version = '^1.0.0', -- optional: only update when a new 1.x version is released
   },
   { -- Better TypeScript LSP integration
@@ -99,16 +147,9 @@ return {
   },
   'ntpeters/vim-better-whitespace', -- highlights trailing whitespace
   { -- Workspace
-    'thaerkh/vim-workspace',
+    'rmagatti/auto-session',
     config = function()
-      vim.keymap.set('n', '<leader>tw', '<cmd>ToggleWorkspace<CR>', { desc = '[T]oggle [W]orkspace' })
-
-      vim.opt.sessionoptions:append 'globals'
-      vim.api.nvim_create_user_command('Mksession', function(attr)
-        vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePre' })
-
-        vim.cmd.mksession { bang = attr.bang, args = attr.fargs }
-      end, { bang = true, complete = 'file', desc = 'Save barbar with :mksession', nargs = '?' })
+      require('auto-session').setup { suppressed_dirs = { '~/', '~/Projects', '~/Downloads', '/' } }
     end,
   },
 }


### PR DESCRIPTION
Added Bufferline, Scope, auto-session
Removed Lightline and vim-workspace

Barbar is disabled. Initially this was my preferred choice for the buffer management, but integration with Scope and auto-session at the same time proved difficult. Bufferline works much better out of the box.